### PR TITLE
SKR-2 use Generic variant

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0.h
@@ -40,6 +40,9 @@
 // USB Flash Drive support
 #define HAS_OTG_USB_HOST_SUPPORT
 
+// Avoid conflict with TIMER_TONE
+#define STEP_TIMER                            10
+
 //
 // Servos
 //

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -202,27 +202,25 @@ extra_scripts     = ${common.extra_scripts}
   pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
 
 #
-# Bigtreetech SKR V2.0 (STM32F407VGT6 ARM Cortex-M4)
-#
-[env:BIGTREE_SKR_2]
-platform          = ${common_stm32.platform}
-extends           = common_stm32
-board             = BigTree_SKR_2
-extra_scripts     = ${common.extra_scripts}
-  pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
-build_flags       = ${common_stm32.build_flags}
-  -DSTM32F407_5VX -DVECT_TAB_OFFSET=0x8000 -DUSE_USB_HS_IN_FS
-
-#
 # Bigtreetech SKR V2.0 (STM32F407VGT6 ARM Cortex-M4) with USB Flash Drive Support
 #
-[env:BIGTREE_SKR_2_usb_flash_drive]
-extends           = env:BIGTREE_SKR_2
-platform_packages = ${stm_flash_drive.platform_packages}
-build_unflags     = -DUSBCON -DUSBD_USE_CDC
+[env:BIGTREE_SKR_2]
+platform             = ${common_stm32.platform}
+platform_packages    = ${stm_flash_drive.platform_packages}
+extends              = common_stm32
+board                = genericSTM32F407VGT6
+board_build.core     = stm32
+board_build.variant  = MARLIN_F4x7Vx
+board_build.ldscript = ldscript.ld
+board_build.offset   = 0x8000
+board_upload.offset_address = 0x08008000
+extra_scripts     = ${common.extra_scripts}
+  pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
+  buildroot/share/PlatformIO/scripts/stm32_bootloader.py
 build_flags       = ${stm_flash_drive.build_flags}
-  -DSTM32F407_5VX -DVECT_TAB_OFFSET=0x8000
-  -DUSBCON -DUSE_USBHOST_HS -DUSBD_IRQ_PRIO=5 -DUSBD_IRQ_SUBPRIO=6 -DUSE_USB_HS_IN_FS -DUSBD_USE_CDC_MSC
+  -DUSE_USBHOST_HS -DUSE_USB_HS_IN_FS -DUSBD_IRQ_PRIO=5 -DUSBD_IRQ_SUBPRIO=6
+  -DHSE_VALUE=8000000U -DHAL_SD_MODULE_ENABLED
+
 
 #
 # Lerdge base


### PR DESCRIPTION
### Requirements

I've tested the following features on SKR-2, and I haven't found any problems caused by variant replacement
- [x] TMC2130-SPI mode & TMC2226-UART mode
- [x] Heating rod * 2 / hotbed  * 1/ thermistor * 3
- [x] CNC Fan * 3
- [x] Endstop ports(`X/Y/Z/-Stop` & `E0/E1-DET` & `PWRDET`) & `PS-ON` port
- [x] Bltouch
- [x] `USB Serial` & TFT port `Serial1`  tested in 115200 boudrate
- [x] LCD12864 & LCD2004 
- [x] Onboard SDIO SD Card & LCD SPI SD
- [x] Onboard USB flash driver
- [x] Neopixel port
- [x]  TMC2130 & TMC2226 driver backward detect

### Description
* SKR-2 use Generic `MARLIN_F4x7Vx` variant
* delete `BIGTREE_SKR_2_usb_flash_drive` environment. SKR-2 hardware uses two sets of USB ports on USB Serial and USB flash driver Instead of GTR or SKR Pro sharing a set of USB.  So SKR-2 doesn't need to separate the two environments. All we need to do is configurate the `USB_FLASH_DRIVE_SUPPORT` and `USE_OTG_USB_HOST` in `configuration_adv.h`
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits
* Avoid more and more redundancy of marlin
<!-- What does this fix or improve? -->

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->

### Related Issues
STM32F4 should be able to use the same variant, including `STM32F407` or `STM32F407` `V`-100pins `Z`-144pins `I`-176pins(These are expectations for the future, and now it's just a discussion)
<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
