### PR TITLE
delete onboard sd detect pin

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0.h
@@ -315,7 +315,6 @@
   #define SDIO_D3_PIN                       PC11
   #define SDIO_CK_PIN                       PC12
   #define SDIO_CMD_PIN                      PD2
-  #define SD_DETECT_PIN                     PC14
 
 #elif SD_CONNECTION_IS(LCD)
 


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Due to the lack of IO, in order to control the three signal lines of TMC SPI separately,  onboard sd detect pin is deleted on mass production SKR-2

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
